### PR TITLE
Remove --allow-hardened argument on kubelet.

### DIFF
--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -7,8 +7,7 @@ Requires=docker.service
 [Service]
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 ExecStart=/usr/bin/kubelet --cloud-provider aws \
-    --config /etc/kubernetes/kubelet/kubelet-config.json \
-    --allow-privileged=true \
+    --config /etc/kubernetes/kubelet/kubelet-config.json \    
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime docker \
     --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS


### PR DESCRIPTION
Feature was deprecated, subsequently removed in version 1.15 of Kubernetes per https://gitlab.truckstop.com/DevOps/Automation/packer-images/-/merge_requests/1